### PR TITLE
bugfix - children attributes show parent type & desc

### DIFF
--- a/src/attributes.erb
+++ b/src/attributes.erb
@@ -30,11 +30,11 @@
             <% hash['children'].each do |child_name, child_hash| %>
               <li class="list-item">
                 <div class="list-item-label">
-                  <div class="list-item-name"><%= name %></div>
-                  <div class="list-item-type"><%= hash['type'] %> </div>
+                  <div class="list-item-name"><%= child_name %></div>
+                  <div class="list-item-type"><%= child_hash['type'] %> </div>
                 </div>
                 <div class="list-item-description">
-                  <p><%= hash['desc'] %></p>
+                  <p><%= child_hash['desc'] %></p>
                 </div>
               </li>
             <% end %>


### PR DESCRIPTION
fix this:
code:
![image](https://user-images.githubusercontent.com/10990867/90137178-8c1f6000-dd75-11ea-8ac4-1e2364d57762.png)
wrong result:
![image](https://user-images.githubusercontent.com/10990867/90137201-96d9f500-dd75-11ea-9afa-79cb02414329.png)
